### PR TITLE
feat: update frontend branding

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -157,13 +157,13 @@
 			v-model="showHelpModal"
 			v-model:articles="articles"
 			appName="learning"
-			title="Frappe Learning"
+                        title="InvenTech Solution Learning"
 			:logo="LMSLogo"
 			:afterSkip="(step) => capture('onboarding_step_skipped_' + step)"
 			:afterSkipAll="() => capture('onboarding_steps_skipped')"
 			:afterReset="(step) => capture('onboarding_step_reset_' + step)"
 			:afterResetAll="() => capture('onboarding_steps_reset')"
-			docsLink="https://docs.frappe.io/learning"
+                        docsLink="https://docs.inventechsolution.com/learning"
 		/>
 		<IntermediateStepModal
 			v-model="showIntermediateModal"

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -1,7 +1,7 @@
 <template>
 	<Dialog v-model="showDialog">
 		<template #body-title>
-			<h2 class="text-lg font-bold">{{ __('Install Frappe Learning') }}</h2>
+                        <h2 class="text-lg font-bold">{{ __('Install InvenTech Solution Learning') }}</h2>
 		</template>
 		<template #body-content>
 			<p>
@@ -29,7 +29,7 @@
 					class="mb-1 flex flex-row items-center justify-between px-3 text-center"
 				>
 					<span class="text-base font-bold text-gray-900">
-						{{ __('Install Frappe Learning') }}
+                                                {{ __('Install InvenTech Solution Learning') }}
 					</span>
 					<span class="inline-flex items-baseline">
 						<FeatherIcon

--- a/frontend/src/components/Modals/EmailTemplateModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateModal.vue
@@ -48,7 +48,7 @@
 					:rows="10"
 					:placeholder="
 						__(
-							'<p>Dear {{ member_name }},</p>\n\n<p>You have been enrolled in our upcoming batch {{ batch_name }}.</p>\n\n<p>Thanks,</p>\n<p>Frappe Learning</p>'
+                                                        '<p>Dear {{ member_name }},</p>\n\n<p>You have been enrolled in our upcoming batch {{ batch_name }}.</p>\n\n<p>Thanks,</p>\n<p>InvenTech Solution Learning</p>'
 						)
 					"
 				/>
@@ -64,7 +64,7 @@
 						:fixedMenu="true"
 						:placeholder="
 							__(
-								'Dear {{ member_name }},\n\nYou have been enrolled in our upcoming batch {{ batch_name }}.\n\nThanks,\nFrappe Learning'
+                                                                'Dear {{ member_name }},\n\nYou have been enrolled in our upcoming batch {{ batch_name }}.\n\nThanks,\nInvenTech Solution Learning'
 							)
 						"
 						editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] max-h-[18rem] overflow-y-auto"

--- a/frontend/src/components/UserDropdown.vue
+++ b/frontend/src/components/UserDropdown.vue
@@ -26,14 +26,17 @@
 					"
 				>
 					<div class="text-base font-medium text-ink-gray-9 leading-none">
-						<span
-							v-if="
-								branding.data?.app_name && branding.data?.app_name != 'Frappe'
-							"
-						>
-							{{ branding.data?.app_name }}
-						</span>
-						<span v-else> Learning </span>
+                                                <span
+                                                        v-if="
+                                                                branding.data?.app_name &&
+                                                                !branding.data?.app_name
+                                                                        ?.toLowerCase()
+                                                                        ?.includes('frappe')
+                                                        "
+                                                >
+                                                        {{ branding.data?.app_name }}
+                                                </span>
+                                                <span v-else> InvenTech Solution Learning </span>
 					</div>
 					<div
 						v-if="userResource.data"
@@ -73,14 +76,14 @@ import { useSettings } from '@/stores/settings'
 import { markRaw, watch, ref, onMounted, computed } from 'vue'
 import { createDialog } from '@/utils/dialogs'
 import SettingsModal from '@/components/Settings/Settings.vue'
-import FrappeCloudIcon from '@/components/Icons/FrappeCloudIcon.vue'
 import {
-	ChevronDown,
-	LogIn,
-	LogOut,
-	Moon,
-	User,
-	Settings,
+        ChevronDown,
+        Cloud,
+        LogIn,
+        LogOut,
+        Moon,
+        User,
+        Settings,
 	Sun,
 	Zap,
 } from 'lucide-vue-next'
@@ -92,7 +95,7 @@ const settingsStore = useSettings()
 let { isLoggedIn } = sessionStore()
 const showSettingsModal = ref(false)
 const theme = ref('light')
-const frappeCloudBaseEndpoint = 'https://frappecloud.com'
+const inventechCloudBaseEndpoint = 'https://cloud.inventechsolution.com'
 const $dialog = createDialog
 
 const props = defineProps({
@@ -166,21 +169,21 @@ const userDropdownOptions = computed(() => {
 						return userResource.data?.is_moderator
 					},
 				},
-				{
-					icon: FrappeCloudIcon,
-					label: 'Login to Frappe Cloud',
-					onClick: () => {
-						$dialog({
-							title: __('Login to Frappe Cloud?'),
-							message: __(
-								'Are you sure you want to login to your Frappe Cloud dashboard?'
-							),
+                                {
+                                        icon: Cloud,
+                                        label: 'Login to InvenTech Solution Cloud',
+                                        onClick: () => {
+                                                $dialog({
+                                                        title: __('Login to InvenTech Solution Cloud?'),
+                                                        message: __(
+                                                                'Are you sure you want to login to your InvenTech Solution Cloud dashboard?'
+                                                        ),
 							actions: [
 								{
 									label: __('Confirm'),
 									variant: 'solid',
 									onClick(close) {
-										loginToFrappeCloud()
+                                                                                loginToInvenTechCloud()
 										close()
 									},
 								},
@@ -221,8 +224,8 @@ const userDropdownOptions = computed(() => {
 	]
 })
 
-const loginToFrappeCloud = () => {
-	let redirect_to = '/dashboard/sites/' + userResource.data.sitename
-	window.open(`${frappeCloudBaseEndpoint}${redirect_to}`, '_blank')
+const loginToInvenTechCloud = () => {
+        let redirect_to = '/dashboard/sites/' + userResource.data.sitename
+        window.open(`${inventechCloudBaseEndpoint}${redirect_to}`, '_blank')
 }
 </script>

--- a/frontend/src/pages/PersonaForm.vue
+++ b/frontend/src/pages/PersonaForm.vue
@@ -18,7 +18,7 @@
 
 				<div class="mb-5">
 					<div class="text-sm text-gray-700 mb-2">
-						{{ __('What is your use case for Frappe Learning?') }}
+                                                {{ __('What is your use case for InvenTech Solution Learning?') }}
 					</div>
 					<FormControl
 						v-model="persona.useCase"


### PR DESCRIPTION
## Summary
- replace visible "Frappe" branding in the Vue frontend with "InvenTech Solution"
- update default email template content and install prompts to use the new name
- refresh the user dropdown cloud login option to reflect the InvenTech Solution Cloud endpoint and icon

## Testing
- yarn build *(fails: missing sites/common_site_config.json referenced by frontend/src/socket.js)*

------
https://chatgpt.com/codex/tasks/task_b_68c83d3e6cd48320a439c5a0f07addb6